### PR TITLE
Removed hardcoded values from wordpress helm chart

### DIFF
--- a/app-wordpress/__main__.py
+++ b/app-wordpress/__main__.py
@@ -19,5 +19,6 @@ wordpress = Chart(
     "wpdev-wordpress",
     LocalChartOpts(
         path="./charts/wordpress"
+        ChartOps
     ),
 )

--- a/app-wordpress/__main__.py
+++ b/app-wordpress/__main__.py
@@ -19,6 +19,5 @@ wordpress = Chart(
     "wpdev-wordpress",
     LocalChartOpts(
         path="./charts/wordpress"
-        ChartOps
-    ),
+    )
 )

--- a/app-wordpress/charts/wordpress/templates/deployment.yaml
+++ b/app-wordpress/charts/wordpress/templates/deployment.yaml
@@ -26,8 +26,8 @@ spec:
            - name: WORDPRESS_DB_HOST
              value: "{{ .Values.database.host }}"
            - name: WORDPRESS_DB_PASSWORD
-             value: "wordpress"
+             value: "{{ .Values.database.password }}"
            - name: WORDPRESS_DB_NAME
-             value: "wordpress"
+             value: "{{ .Values.database.name }}"
            - name: WORDPRESS_DB_USER
-             value: "wordpress"
+             value: "{{ .Values.database.user }}"

--- a/app-wordpress/charts/wordpress/values.yaml
+++ b/app-wordpress/charts/wordpress/values.yaml
@@ -11,6 +11,9 @@ image:
 
 database:
   host: wpdev-mariadb
+  name: wordpress
+  user: wordpress
+  password: wordpress
 
 service:
   type: NodePort
@@ -31,3 +34,4 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+


### PR DESCRIPTION
Wordpress deployment template contained hardcoded values that needed to be pulled from the chart values.yaml file so that they can be overwritten.