### PR TITLE
Addition of aws accounts to support asterion infra environments and resource visibility

### DIFF
--- a/org-asterion/__main__.py
+++ b/org-asterion/__main__.py
@@ -96,3 +96,23 @@ admin_team = aws.iam.GroupMembership(
     ],
     group=admin_group.name
     )
+
+# Create asterion infra-aws environment accounts
+asterion_infra_aws_dev_acc = aws.organizations.Account(
+    "asterion-infra-aws-dev-team", 
+    email="asterion-dev-team@asterion.digital", 
+    name="Asterion Infra-AWS Dev Team", 
+    parent_id=asterion_infra_aws_dev.id
+)
+asterion_infra_aws_test_acc = aws.organizations.Account(
+    "asterion-infra-aws-test-team", 
+    email="asterion-test-team@asterion.digital", 
+    name="Asterion Infra-AWS Test Team", 
+    parent_id=asterion_infra_aws_test.id
+)
+asterion_infra_aws_prod_acc = aws.organizations.Account(
+    "asterion-infra-aws-prod-team", 
+    email="asterion-prod-team@asterion.digital", 
+    name="Asterion Infra-AWS Prod Team", 
+    parent_id=asterion_infra_aws_prod.id
+)


### PR DESCRIPTION
I've created three accounts representing asterion development environments (I.E dev/test/prod) under their respective organizational units in aws. These accounts will be used to manage the roles and policies applicable to each environment. Once these roles are configured, they will allow users to assume roles in each environment to create and maintain resources in that environment. The accounts are also the foundational block to auditing resource usage per environment, and consolidate these costs into a single aws bill. 