### PR TITLE
Added policies to govern user activity in aws master and stack accounts

### DIFF
--- a/org-asterion/__main__.py
+++ b/org-asterion/__main__.py
@@ -90,7 +90,7 @@ else:
         pulumi.log.info("PYLOGGER (" + str(datetime.datetime.now()) + "): " + str(err))
 
 # Create an aws iam assumerole policy and attach it to this account
-awspolicies.create_attach_assumerole_policy([Output.concat("arn:aws:iam::", account_id, ":role/administrator")], groupname)
+awspolicies.create_attach_policies([Output.concat("arn:aws:iam::", account_id, ":role/administrator")], groupname)
 
 # Set stack update object
 stack_update = update_stack.UpdateStackAccount(asterion_users)

--- a/org-asterion/modules/account.py
+++ b/org-asterion/modules/account.py
@@ -27,6 +27,7 @@ class account:
                 email="asterion-infra-aws-" + str(self.environment) + "@asterion.digital",
                 name="Asterion Infra-AWS " + str(self.environment.capitalize()) + " Team",
                 parent_id=self.parent_ou.id,
+                iam_user_access_to_billing="ALLOW",
                 opts=pulumi.ResourceOptions(
                     retain_on_delete=True
                 )

--- a/org-asterion/modules/policies.py
+++ b/org-asterion/modules/policies.py
@@ -8,22 +8,51 @@ from pulumi import ResourceOptions
 # Define and attach an asterion assumerole policy for this stack
 def create_attach_assumerole_policy(resources, groupname):
 
-    # Create a policy document for the assumerole policies
+    # Create a policy document for the `admins` group providing permissions over master account global resources
     assumerole_policy_document = aws.iam.get_policy_document(
         statements=[
+
+            # Create the assumerole policies
             aws.iam.GetPolicyDocumentStatementArgs(
                 actions=[
                     "sts:AssumeRole"
                 ],
                 effect="Allow",
                 resources=resources
+            ),
+
+            # Create the aws billing policies
+            aws.iam.GetPolicyDocumentStatementArgs(
+                actions=[
+                    "aws-portal:ViewBilling",
+                    "aws-portal:ViewUsage",
+                    "aws-portal:ViewAccount",
+                    "aws-portal:ViewBudget",
+                    "ce:GetPreferences",
+                    "ce:DescribeReport",
+                    "ce:ListTagsForResource"
+                ],
+                effect="Allow",
+                resources=["*"]
+            ),
+
+            # Create the read-only iam policies
+            aws.iam.GetPolicyDocumentStatementArgs(
+                actions=[
+                    "iam:Get*",
+                    "iam:List*",
+                    "iam:Generate*",
+                    "organizations:List*"
+                ],
+                effect="Allow",
+                resources=["*"]
             )
         ]
     )
 
     # Create a policy from the policy document
     assumerole_policy = aws.iam.Policy(
-        "asterion-group-admins-policy",
+        "asterion-group-admins-assumerole-policy",
         description="AssumeRole policy for the asterion-admins group",
         policy=assumerole_policy_document.json
     )
@@ -38,8 +67,44 @@ def create_attach_assumerole_policy(resources, groupname):
         )
     )
 
-# Define and attach asterion resource policies for admin users in this stack
+    # # Create a policy document to control read-only billing permissions
+    # readbilling_policy_document = aws.iam.get_policy_document(
+    #     statements=[
+    #         aws.iam.GetPolicyDocumentStatementArgs(
+    #             actions=[
+    #                 "aws-portal:ViewBilling",
+    #                 "aws-portal:ViewUsage",
+    #                 "aws-portal:ViewAccount",
+    #                 "aws-portal:ViewBudget",
+    #                 "ce:GetPreferences",
+    #                 "ce:DescribeReport",
+    #                 "ce:ListTagsForResource",
+    #                 "ce:ListTagsForResource",
+    #             ],
+    #             effect="Allow"
+    #         )
+    #     ]
+    # )
 
-# Allow users to modify THEIR OWN iam re accesskeys
+    # # Create a policy from the policy document
+    # readbilling_policy = aws.iam.Policy(
+    #     "asterion-group-admins-readbilling-policy",
+    #     description="Read-only billing policy for the asterion-admins group",
+    #     policy=readbilling_policy_document.json
+    # )
 
-# Allow admin users to be able to deploy all services in dev aws account
+    # # Attach the readbilling policy document to the admins group policy
+    # readbilling_policy_attach = aws.iam.GroupPolicyAttachment(
+    #     "asterion-group-admins-policy-attachment",
+    #     group=groupname,
+    #     policy_arn=assumerole_policy.arn,
+    #     opts=pulumi.ResourceOptions(
+    #         depends_on=[assumerole_policy]
+    #     )
+    # )
+
+# TODO: Define and attach asterion resource policies for admin users in this stack -- 
+
+# Allow users to modify THEIR OWN iam re accesskeys -- TEST AND CHECK
+
+# TODO: Allow admin users to be able to deploy all services in dev aws account

--- a/org-asterion/modules/policies.py
+++ b/org-asterion/modules/policies.py
@@ -5,14 +5,14 @@ import pulumi
 import pulumi_aws as aws
 from pulumi import ResourceOptions
 
-# Define and attach an asterion assumerole policy for this stack
-def create_attach_assumerole_policy(resources, groupname):
+# Define and attach aws policies that govern administrators of the asterion master account
+def create_attach_policies(resources, groupname):
 
-    # Create a policy document for the `admins` group providing permissions over master account global resources
-    assumerole_policy_document = aws.iam.get_policy_document(
+    # Create a policy document that will be converted to json
+    policy_document = aws.iam.get_policy_document(
         statements=[
 
-            # Create the assumerole policies
+            # Allow administrators to switch iam roles
             aws.iam.GetPolicyDocumentStatementArgs(
                 actions=[
                     "sts:AssumeRole"
@@ -21,22 +21,19 @@ def create_attach_assumerole_policy(resources, groupname):
                 resources=resources
             ),
 
-            # Create the aws billing policies
+            # Allow administrators to view aws billing information
             aws.iam.GetPolicyDocumentStatementArgs(
                 actions=[
-                    "aws-portal:ViewBilling",
-                    "aws-portal:ViewUsage",
-                    "aws-portal:ViewAccount",
-                    "aws-portal:ViewBudget",
-                    "ce:GetPreferences",
-                    "ce:DescribeReport",
-                    "ce:ListTagsForResource"
+                    "aws-portal:View*",
+                    "ce:Get*",
+                    "ce:Describe*",
+                    "ce:List*"
                 ],
                 effect="Allow",
                 resources=["*"]
             ),
 
-            # Create the read-only iam policies
+            # Allow administrators to view aws iam information
             aws.iam.GetPolicyDocumentStatementArgs(
                 actions=[
                     "iam:Get*",
@@ -51,60 +48,20 @@ def create_attach_assumerole_policy(resources, groupname):
     )
 
     # Create a policy from the policy document
-    assumerole_policy = aws.iam.Policy(
-        "asterion-group-admins-assumerole-policy",
-        description="AssumeRole policy for the asterion-admins group",
-        policy=assumerole_policy_document.json
+    policy = aws.iam.Policy(
+        "asterion-secpolicies-admins-group-policy",
+        description="Policies for the asterion-admins group",
+        policy=policy_document.json
     )
 
-    # Attach the assumerole policy document to the admins group policy
-    assumerole_policy_attach = aws.iam.GroupPolicyAttachment(
-        "asterion-group-admins-policy-attachment",
+    # Attach the policies to the `admins` iam group
+    policy_attach = aws.iam.GroupPolicyAttachment(
+        "asterion-secpolicies-admins-group-policy-attachment",
         group=groupname,
-        policy_arn=assumerole_policy.arn,
+        policy_arn=policy.arn,
         opts=pulumi.ResourceOptions(
-            depends_on=[assumerole_policy]
+            depends_on=[policy]
         )
     )
-
-    # # Create a policy document to control read-only billing permissions
-    # readbilling_policy_document = aws.iam.get_policy_document(
-    #     statements=[
-    #         aws.iam.GetPolicyDocumentStatementArgs(
-    #             actions=[
-    #                 "aws-portal:ViewBilling",
-    #                 "aws-portal:ViewUsage",
-    #                 "aws-portal:ViewAccount",
-    #                 "aws-portal:ViewBudget",
-    #                 "ce:GetPreferences",
-    #                 "ce:DescribeReport",
-    #                 "ce:ListTagsForResource",
-    #                 "ce:ListTagsForResource",
-    #             ],
-    #             effect="Allow"
-    #         )
-    #     ]
-    # )
-
-    # # Create a policy from the policy document
-    # readbilling_policy = aws.iam.Policy(
-    #     "asterion-group-admins-readbilling-policy",
-    #     description="Read-only billing policy for the asterion-admins group",
-    #     policy=readbilling_policy_document.json
-    # )
-
-    # # Attach the readbilling policy document to the admins group policy
-    # readbilling_policy_attach = aws.iam.GroupPolicyAttachment(
-    #     "asterion-group-admins-policy-attachment",
-    #     group=groupname,
-    #     policy_arn=assumerole_policy.arn,
-    #     opts=pulumi.ResourceOptions(
-    #         depends_on=[assumerole_policy]
-    #     )
-    # )
-
-# TODO: Define and attach asterion resource policies for admin users in this stack -- 
-
-# Allow users to modify THEIR OWN iam re accesskeys -- TEST AND CHECK
 
 # TODO: Allow admin users to be able to deploy all services in dev aws account

--- a/org-asterion/modules/update_stack.py
+++ b/org-asterion/modules/update_stack.py
@@ -42,9 +42,7 @@ class UpdateStackAccount:
                 aws.iam.GetPolicyDocumentStatementArgs(
                     actions=[
                         "cloudwatch:*",
-                        "dynamodb:*",
-                        "ec2:*",
-                        "s3:*"
+                        "ec2:*"
                     ],
                     effect="Allow",
                     resources=[

--- a/org-asterion/modules/update_stack.py
+++ b/org-asterion/modules/update_stack.py
@@ -66,8 +66,6 @@ class UpdateStackAccount:
             )
         )
 
-        pulumi.export("Test outputting user arns", self.users.arns)
-
         # Define a policy document that allows the administrator role to be assumed
         self.assume_role_policy = aws.iam.get_policy_document(
             statements=[

--- a/org-asterion/modules/update_stack.py
+++ b/org-asterion/modules/update_stack.py
@@ -38,14 +38,19 @@ class UpdateStackAccount:
         self.resource_policy = aws.iam.get_policy_document(
             statements=[
 
-                # Grant open EC2 priviledges in stack account
+                # Allow open permissions across common aws services
                 aws.iam.GetPolicyDocumentStatementArgs(
                     actions=[
-                        "ec2:*"
+                        "cloudwatch:*",
+                        "dynamodb:*",
+                        "ec2:*",
+                        "s3:*"
                     ],
                     effect="Allow",
                     resources=[
-                        Output.concat("arn:aws:ec2::", self.stack_account_id,":*")
+                        Output.concat("arn:aws:dynamodb::", self.stack_account_id,":*"),
+                        Output.concat("arn:aws:ec2::", self.stack_account_id,":*"),
+                        Output.concat("arn:aws:s3:::*")
                     ]
                 ),
                 # Grant read-only iam priviledges


### PR DESCRIPTION
I've added policies that grant read-only access for administrators to view iams and billing data in the master account. I've added policies that grant administrators full access to common aws services.