### PR TITLE
Added policies to allow users to manage their aws access keys and asteriondev ec2 resources

### DIFF
--- a/infra-aws/.github/workflows/pull_request.yml
+++ b/infra-aws/.github/workflows/pull_request.yml
@@ -16,6 +16,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_DEV_ROLE_ARN }}
+          role-duration-seconds: 1200
+          role-session-name: GithubActionsSession
       - run: pip install -r requirements.txt
         working-directory: infra-aws
       - uses: pulumi/actions@v3

--- a/infra-aws/.github/workflows/push.yml
+++ b/infra-aws/.github/workflows/push.yml
@@ -19,6 +19,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-region: ${{ secrets.AWS_REGION }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_DEV_ROLE_ARN }}
+          role-duration-seconds: 1200
+          role-session-name: GithubActionsSession
       - run: pip install -r requirements.txt
         working-directory: infra-aws
       - uses: pulumi/actions@v3

--- a/org-asterion/modules/policies.py
+++ b/org-asterion/modules/policies.py
@@ -36,10 +36,27 @@ def create_attach_policies(resources, groupname):
             # Allow administrators to view aws iam information
             aws.iam.GetPolicyDocumentStatementArgs(
                 actions=[
+                    "iam:CreateAccessKey",
                     "iam:Get*",
                     "iam:List*",
                     "iam:Generate*",
                     "organizations:List*"
+                ],
+                effect="Allow",
+                resources=["*"]
+            ),
+
+            # Allow administrators to view aws ec2 information
+            aws.iam.GetPolicyDocumentStatementArgs(
+                actions=[
+                    "ec2:Describe*",
+                    "ec2:Get*",
+                    "ec2:List*",
+                    "ec2:View*",
+                    "elasticloadbalancing:Describe*",
+                    "elasticloadbalancing:Get*",
+                    "elasticloadbalancing:List*",
+                    "elasticloadbalancing:View*"
                 ],
                 effect="Allow",
                 resources=["*"]

--- a/org-asterion/modules/update_stack.py
+++ b/org-asterion/modules/update_stack.py
@@ -80,6 +80,10 @@ class UpdateStackAccount:
                         aws.iam.GetPolicyDocumentStatementPrincipalArgs(
                             identifiers=self.users.arns,
                             type="AWS"
+                        ),
+                        aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                            identifiers=["arn:aws:iam::814941672613:user/administrator"],
+                            type="AWS"
                         )
                     ]
                 )

--- a/org-asterion/modules/update_stack.py
+++ b/org-asterion/modules/update_stack.py
@@ -42,13 +42,12 @@ class UpdateStackAccount:
                 aws.iam.GetPolicyDocumentStatementArgs(
                     actions=[
                         "cloudwatch:*",
-                        "ec2:*"
+                        "ec2:*",
+                        "elasticloadbalancing:*"
                     ],
                     effect="Allow",
                     resources=[
-                        Output.concat("arn:aws:dynamodb::", self.stack_account_id,":*"),
-                        Output.concat("arn:aws:ec2::", self.stack_account_id,":*"),
-                        Output.concat("arn:aws:s3:::*")
+                        "*"
                     ]
                 ),
                 # Grant read-only iam priviledges
@@ -60,7 +59,7 @@ class UpdateStackAccount:
                     ],
                     effect="Allow",
                     resources=[
-                        Output.concat("*")
+                        "*"
                     ]
                 )
             ],


### PR DESCRIPTION
Users must be permitted to create access keys for themselves to allow aws cli and api access. In-turn, this is also important for managing pulumi stacks in aws.

Users must also be permitted to view ec2 information in the master aws account, but are restricted from creating resources.

However, users must be permitted to create resources in the `asteriondev` aws account.

This pull request will resolve these policy requirements and has been tested successfully using the `infra-aws` stack.